### PR TITLE
Add clone trait for moving value easily

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -24,6 +24,7 @@ use super::worker::Worker;
 pub use self::http::{Config as HttpConfig, Runner as HttpRunner};
 pub use self::stratum::{Config as StratumConfig, Runner as StratumRunner};
 
+#[derive(Clone)]
 pub enum RpcConfig {
     Http(HttpConfig),
     Stratum(StratumConfig),


### PR DESCRIPTION
To merge the detailed values of RPC into one config value in blake/cuckoo miner

```
pub struct CuckooConfig {
    pub max_vertex: usize,
    pub max_edge: usize,
    pub cycle_length: usize,

    pub listening_port: u16,
    pub submitting_port: u16,

    pub concurrent_jobs: u16,
}

->

pub struct CuckooConfig {
    pub max_vertex: usize,
    pub max_edge: usize,
    pub cycle_length: usize,

    pub rpc_config: RpcConfig,
    
    pub concurrent_jobs: u16,
}
```